### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ An example project is included with this repo. To run the example project, clone
 
 ## Author
 
-###Barbara M Brina
+### Barbara M Brina
 * barbara@brina.mx
 * [Website](http://brina.mx)
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
